### PR TITLE
Rename `pep8` task to `lint`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,14 @@ workflows:
   version: 2
   build:
     jobs:
-      - pep8
+      - lint
       - webpage
       - py27:
           requires:
-            - pep8
+            - lint
       - py36:
           requires:
-            - pep8
+            - lint
   deploy:
     jobs:
       - deploy:
@@ -31,13 +31,13 @@ workflows:
               only:
                 - master
     jobs:
-      - pep8
+      - lint
       - py27:
           requires:
-            - pep8
+            - lint
       - py36:
           requires:
-            - pep8
+            - lint
 
 jobs:
   base: &test-template
@@ -63,7 +63,7 @@ jobs:
             - ./venv
             - ./.tox
 
-  pep8:
+  lint:
     <<: *test-template
 
   py27:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
   include:
     - stage: Lint scripts
       python: 3.6
-      env: TOXENV=pep8
+      env: TOXENV=lint
       script: tox
     - stage: Test scripts and webage
       script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py27,py36,pep8
+envlist = py27,py36,lint
 
 [testenv]
 commands = python setup.py test
 
-[testenv:pep8]
+[testenv:lint]
 deps =
      flake8
      pycodestyle


### PR DESCRIPTION
The new name is a bit more general.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>